### PR TITLE
init_app() should not use self.app

### DIFF
--- a/flask_xstatic_files.py
+++ b/flask_xstatic_files.py
@@ -56,7 +56,7 @@ class XStaticFiles(object):
         else:
             app.teardown_request(self.teardown)
 
-        self.app.jinja_env.globals['xstatic_url_for'] = self.url_for
+        app.jinja_env.globals['xstatic_url_for'] = self.url_for
 
         @app.route('/xstatic/<module>/<path:filename>')
         def xstatic(module, filename):


### PR DESCRIPTION
Don't you want app here and not self.app?  I'm setting up flask with a create_app() factory and separate config class.

Without this change I get: "AttributeError: 'NoneType' object has no attribute 'jinja_env'"

And with this change I get some other error, but I get past that one.